### PR TITLE
Show directory size as empty string

### DIFF
--- a/src/FileInfo.ps1
+++ b/src/FileInfo.ps1
@@ -29,7 +29,8 @@ function Write-Color-LS
 {
     param ([string]$color = "white", $file)
 
-    Write-host ("{0,-7} {1,25} {2,10} {3}" -f $file.mode, ([String]::Format("{0,10}  {1,8}", $file.LastWriteTime.ToString("d"), $file.LastWriteTime.ToString("t"))), (Write-FileLength $file.length), $file.name) -foregroundcolor $color
+    $length = if ($file -is [System.IO.DirectoryInfo]) { $null } else { $file.length }
+    Write-host ("{0,-7} {1,25} {2,10} {3}" -f $file.mode, ([String]::Format("{0,10}  {1,8}", $file.LastWriteTime.ToString("d"), $file.LastWriteTime.ToString("t"))), (Write-FileLength $length), $file.name) -foregroundcolor $color
 }
 
 function FileInfo {


### PR DESCRIPTION
This will fix #6.

`Write-FileLength` already handles `$null` nicely, so all I had to do is just pass a `$null` instead of `length` of a directory.

`.Length` returns `1` for directories because `System.IO.DirectoryInfo` actually have no `Length` property, so PowerShell wraps it into an single-item array and returns its length.
