### PR TITLE
Repeat header when listing the next directory

### DIFF
--- a/src/FileInfo.ps1
+++ b/src/FileInfo.ps1
@@ -35,11 +35,11 @@ function Write-Color-LS
 function FileInfo {
     param (
         [Parameter(Mandatory=$True,Position=1)]
-        $file
+        [System.IO.FileSystemInfo] $file
     )
 
     $regex_opts = ([System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
-
+	
     $hidden = New-Object System.Text.RegularExpressions.Regex(
         $global:PSColor.File.Hidden.Pattern, $regex_opts)
     $code = New-Object System.Text.RegularExpressions.Regex(
@@ -51,14 +51,21 @@ function FileInfo {
     $compressed = New-Object System.Text.RegularExpressions.Regex(
         $global:PSColor.File.Compressed.Pattern, $regex_opts)
 
-    if($script:showHeader)
+	if ($file -is [System.IO.DirectoryInfo])
+	{
+	    $currentdir = $file.Parent.FullName
+	} else 
+	{
+		$currentdir = $file.DirectoryName
+	}
+    if($script:directory -ne $currentdir)
     {
+	   $script:directory = $currentdir
        Write-Host
-       Write-Host "    Directory: " -noNewLine
-       Write-Host " $(pwd)`n" -foregroundcolor "Green"
+       Write-Host "    Directory: " -noNewLine	   
+       Write-Host " $currentdir`n" -foregroundcolor "Green"
        Write-Host "Mode                LastWriteTime     Length Name"
        Write-Host "----                -------------     ------ ----"
-       $script:showHeader=$false
     }
 
     if ($hidden.IsMatch($file.Name))

--- a/src/PSColor.psm1
+++ b/src/PSColor.psm1
@@ -17,7 +17,7 @@ $global:PSColor = @{
         Code       = @{ Color = 'Magenta'; Pattern = '\.(java|c|cpp|cs|js|css|html)$' }
         Executable = @{ Color = 'Red'; Pattern = '\.(exe|bat|cmd|py|pl|ps1|psm1|vbs|rb|reg)$' }
         Text       = @{ Color = 'Yellow'; Pattern = '\.(txt|cfg|conf|ini|csv|log|config|xml|yml|md|markdown)$' }
-        Compressed = @{ Color = 'Green'; Pattern = '\.(zip|tar|gz|rar|jar|war)$' }
+        Compressed = @{ Color = 'Green'; Pattern = '\.(zip|tar|gz|rar|jar|war|7z)$' }
     }
     Service = @{
         Default = @{ Color = 'White' }


### PR DESCRIPTION
Fixes #8 and #5.

`dir c:\,x:\` should list files from both c:\ and x:\ and print appropriate headers. The files are assumed to be sorted (i.e. list all files from first location followed by second location).
